### PR TITLE
Added version check, renamed --repl to -i and fixed bug with banner

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.DS_Store
+.vscode
+

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,7 @@ def get_arguments():
     parser.add_argument('infile', nargs='?', default=None, type=str, help='The optional input file')
     parser.add_argument('--debug', action='store_true', default=False,
             help='Enables full debugging from startup (equivalent to running !debug as first command)')
-    parser.add_argument('--repl', action='store_true', default=False,
+    parser.add_argument('-i', dest="repl", action='store_true', default=False,
             help='Only useful when infile is provided, in which case this forces the parser to drop into a repl after executing the file')
 #    parser.add_argument('--stable', action='store_true', default=False,
 #            help='Switch global system to use stable espresso and quit')
@@ -113,7 +113,7 @@ def do_repl(config):
     # initialize the repl
     if config.infile is not None:
         if not os.path.isfile(config.infile):
-            os.r(f'file {config.infile} not found')
+            u.r(f'file {config.infile} not found')
             exit(1)
     the_repl = repl.Repl(config)
 

--- a/src/repl.py
+++ b/src/repl.py
@@ -138,13 +138,14 @@ class Context:
             u.gray(f"input_from_file called")
             self.line_idx += 1
             if self.line_idx >= len(self.lines):
-                u.gray(f"Context switch: {self.infile} -> {self.prev_context.infile}")
+                u.gray(f"Context switch: {self.prev_context.infile} -> {self.infile}")
                 self.repl.context = self.prev_context
                 self.repl.mode = self.old_mode # reset mode as exiting this context. Then again, it'll always be normal mode that calls `use` statements
                 if self.repl.context == None:
                     u.gray('Final context ended, exit()ing')
                     exit(0)
-                return self.repl.context.input(banner) # smoothly transition into the next input source
+                self.repl.update_banner()
+                return self.repl.context.input(self.repl.banner) # smoothly transition into the next input source
             line = self.lines[self.line_idx]
             print(f"compiling:{line}")
             return line
@@ -165,6 +166,7 @@ class Context:
                 u.r(f"failed to open file {infile} for Context creation")
                 return
         repl.context = self
+
     def input(self):
         u.r("SHOULD HAVE BEEN OVERWRITTEN") # is overwritten in __init__
 

--- a/src/start.py
+++ b/src/start.py
@@ -1,8 +1,10 @@
 #!/usr/local/bin/python3
 
-
 ## code that goes here is stuff can can only ever be run a single time.
 
+import sys
+if sys.version_info[0] < 3 or sys.version_info[1] < 7:
+    raise Exception("Must be using Python 3.7 or higher")
 
 while True:
     try:
@@ -13,7 +15,9 @@ while True:
         continue
 
     ## we REALLY only want this to run once with loading lots of text from files, hence we put it in a module that never gets reloaded
-    import readline, os, sys
+    import readline
+    import os
+
     try:
         readline.clear_history()
         readline.read_history_file(u.histfile)
@@ -23,7 +27,6 @@ while True:
         pass
 
 ## `atexit` doesn't seem to work when a process exits with nonzero code like when it gets killed by a SIGHUP from the terminal, however my signal.signal() efforts havent achieved anything. By testing with SIGALRM clearly the signals are being set correctly (for alarm at least) but then they never seem to fire. Note that it could have to do with ctrl-z in iterm2 allowing for revivals -- this should be tested with Terminal.app as well. Note as well that ctrl-d is handled in repl.py and calls exit(0) after saving the history. However bash seems to save history even when the terminal is killed (at least in Terminal.app), so it'd be nice to do that.
-
 
 
 #    import atexit
@@ -46,15 +49,11 @@ while True:
     # write history on exiting
     #atexit.register(cleanup)
 
-
-
     try:
         import main
         main.main()
-        break # the end!
+        break  # the end!
     except Exception as e:
-        print(u.format_exception(e,u.src_path,verbose=True))
+        print(u.format_exception(e, u.src_path, verbose=True))
         input(u.mk_g("[Reload with ENTER]"))
         continue
-
-


### PR DESCRIPTION
Added version check for users below Python 3.7. Renamed the --repl flag to -i to match Python. Fixed a bug with the banner not updating when exiting the file input mode. Changed an incorrect call to os.r to u.r, added .gitignore.